### PR TITLE
fix: read light from front camera on iOS (optional)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ migrate_working_dir/
 **/doc/api/
 .dart_tool/
 build/
+
+.vscode

--- a/ios/Classes/AmbientLightPlugin.swift
+++ b/ios/Classes/AmbientLightPlugin.swift
@@ -25,14 +25,19 @@ public class AmbientLightPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
                 result(FlutterError(code: "IN_PROGRESS", message: "Another ambient light request is in progress", details: nil))
             } else {
                 self.result = result
-                startListeningForResult()
+                if let args = call.arguments as? [String: Any],
+                   let useFrontCamera = args["useFrontCamera"] as? Bool {
+                    startListeningForResult(frontCamera: useFrontCamera)
+                } else {
+                    startListeningForResult()
+                }
             }
         default:
             result(FlutterMethodNotImplemented)
         }
     }
 
-    private func startListeningForResult() {
+    private func startListeningForResult(frontCamera: Bool = false) {
         if captureSession == nil {
             captureSession = AVCaptureSession()
         }
@@ -42,7 +47,9 @@ public class AmbientLightPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
             return
         }
 
-        guard let device = AVCaptureDevice.default(for: .video) else {
+        let position: AVCaptureDevice.Position = frontCamera ? .front : .back
+
+        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: position) else {
             result?(FlutterError(code: "NO_DEVICE", message: "No video device available", details: nil))
             return
         }
@@ -66,7 +73,7 @@ public class AmbientLightPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
         captureSession.startRunning()
     }
 
-    private func startListening() {
+    private func startListening(frontCamera: Bool = false) {
         if captureSession == nil {
             captureSession = AVCaptureSession()
         }
@@ -76,7 +83,9 @@ public class AmbientLightPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
             return
         }
 
-        guard let device = AVCaptureDevice.default(for: .video) else {
+        let position: AVCaptureDevice.Position = frontCamera ? .front : .back
+
+        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: position) else {
             eventSink?(FlutterError(code: "NO_DEVICE", message: "No video device available", details: nil))
             return
         }
@@ -108,7 +117,11 @@ public class AmbientLightPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
 
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         self.eventSink = events
-        startListening()
+
+        if let args = arguments as? [String: Any],
+        let useFrontCamera = args["useFrontCamera"] as? Bool{
+            startListening(frontCamera: useFrontCamera)
+        }
         return nil
     }
 

--- a/lib/ambient_light.dart
+++ b/lib/ambient_light.dart
@@ -1,11 +1,13 @@
 import 'ambient_light_platform_interface.dart';
 
 class AmbientLight {
-  Future<double?> currentAmbientLight() async {
-    final double? lux = await AmbientLightPlatform.instance.getAmbientLight();
+  Future<double?> currentAmbientLight({bool useFrontCamera = false}) async {
+    final double? lux = await AmbientLightPlatform.instance
+        .getAmbientLight(useFrontCameraOnIOS: useFrontCamera);
     return lux;
   }
 
-  Stream<double> get ambientLightStream =>
-      AmbientLightPlatform.instance.ambientLightStream;
+  Stream<double> ambientLightStream({bool useFrontCamera = false}) =>
+      AmbientLightPlatform.instance
+          .ambientLightStream(useFrontCameraOnIOS: useFrontCamera);
 }

--- a/lib/ambient_light.dart
+++ b/lib/ambient_light.dart
@@ -1,13 +1,19 @@
 import 'ambient_light_platform_interface.dart';
 
 class AmbientLight {
-  Future<double?> currentAmbientLight({bool useFrontCamera = false}) async {
+  /// Returns the current ambient light in lux.
+  /// if [frontCamera] is true, the front camera will be used.
+  /// Important: [frontCamera] is only available on iOS.
+  Future<double?> currentAmbientLight({bool frontCamera = false}) async {
     final double? lux = await AmbientLightPlatform.instance
-        .getAmbientLight(useFrontCameraOnIOS: useFrontCamera);
+        .getAmbientLight(frontCamera: frontCamera);
     return lux;
   }
 
-  Stream<double> ambientLightStream({bool useFrontCamera = false}) =>
+  /// Returns a stream of ambient light in lux.
+  /// if [frontCamera] is true, the front camera will be used.
+  /// Important: [frontCamera] is only available on iOS.
+  Stream<double> ambientLightStream({bool frontCamera = false}) =>
       AmbientLightPlatform.instance
-          .ambientLightStream(useFrontCameraOnIOS: useFrontCamera);
+          .ambientLightStream(frontCamera: frontCamera);
 }

--- a/lib/ambient_light_method_channel.dart
+++ b/lib/ambient_light_method_channel.dart
@@ -14,13 +14,15 @@ class MethodChannelAmbientLight extends AmbientLightPlatform {
       const EventChannel('ambient_light_stream.aliyou.dev');
 
   @override
-  Future<double?> getAmbientLight() async {
-    final double? lux = await methodChannel.invokeMethod('getAmbientLight');
+  Future<double?> getAmbientLight({bool useFrontCameraOnIOS = false}) async {
+    final double? lux = await methodChannel
+        .invokeMethod('getAmbientLight', {'useFrontCamera': useFrontCameraOnIOS});
     return lux;
   }
 
   @override
-  Stream<double> get ambientLightStream {
-    return eventChannel.receiveBroadcastStream().map((lux) => lux as double);
+  Stream<double> ambientLightStream({bool useFrontCameraOnIOS = false}) {
+    return eventChannel.receiveBroadcastStream(
+        {'useFrontCamera': useFrontCameraOnIOS}).map((lux) => lux as double);
   }
 }

--- a/lib/ambient_light_method_channel.dart
+++ b/lib/ambient_light_method_channel.dart
@@ -14,15 +14,15 @@ class MethodChannelAmbientLight extends AmbientLightPlatform {
       const EventChannel('ambient_light_stream.aliyou.dev');
 
   @override
-  Future<double?> getAmbientLight({bool useFrontCameraOnIOS = false}) async {
+  Future<double?> getAmbientLight({bool frontCamera = false}) async {
     final double? lux = await methodChannel
-        .invokeMethod('getAmbientLight', {'useFrontCamera': useFrontCameraOnIOS});
+        .invokeMethod('getAmbientLight', {'useFrontCamera': frontCamera});
     return lux;
   }
 
   @override
-  Stream<double> ambientLightStream({bool useFrontCameraOnIOS = false}) {
+  Stream<double> ambientLightStream({bool frontCamera = false}) {
     return eventChannel.receiveBroadcastStream(
-        {'useFrontCamera': useFrontCameraOnIOS}).map((lux) => lux as double);
+        {'useFrontCamera': frontCamera}).map((lux) => lux as double);
   }
 }

--- a/lib/ambient_light_platform_interface.dart
+++ b/lib/ambient_light_platform_interface.dart
@@ -23,11 +23,11 @@ abstract class AmbientLightPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<double?> getAmbientLight() async {
+  Future<double?> getAmbientLight({bool useFrontCameraOnIOS = false}) async {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
-  Stream<double> get ambientLightStream {
+  Stream<double> ambientLightStream({bool useFrontCameraOnIOS = false}) {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 }

--- a/lib/ambient_light_platform_interface.dart
+++ b/lib/ambient_light_platform_interface.dart
@@ -23,11 +23,11 @@ abstract class AmbientLightPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<double?> getAmbientLight({bool useFrontCameraOnIOS = false}) async {
+  Future<double?> getAmbientLight({bool frontCamera = false}) async {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
-  Stream<double> ambientLightStream({bool useFrontCameraOnIOS = false}) {
+  Stream<double> ambientLightStream({bool frontCamera = false}) {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 }

--- a/test/ambient_light_test.dart
+++ b/test/ambient_light_test.dart
@@ -8,10 +8,12 @@ class MockAmbientLightPlatform
     with MockPlatformInterfaceMixin
     implements AmbientLightPlatform {
   @override
-  Stream<double> get ambientLightStream => Stream.value(42);
+  Stream<double> ambientLightStream({bool useFrontCameraOnIOS = false}) =>
+      Stream.value(42);
 
   @override
-  Future<double?> getAmbientLight() => Future.value(42);
+  Future<double?> getAmbientLight({bool useFrontCameraOnIOS = false}) =>
+      Future.value(42);
 }
 
 void main() {

--- a/test/ambient_light_test.dart
+++ b/test/ambient_light_test.dart
@@ -8,11 +8,11 @@ class MockAmbientLightPlatform
     with MockPlatformInterfaceMixin
     implements AmbientLightPlatform {
   @override
-  Stream<double> ambientLightStream({bool useFrontCameraOnIOS = false}) =>
+  Stream<double> ambientLightStream({bool frontCamera = false}) =>
       Stream.value(42);
 
   @override
-  Future<double?> getAmbientLight({bool useFrontCameraOnIOS = false}) =>
+  Future<double?> getAmbientLight({bool frontCamera = false}) =>
       Future.value(42);
 }
 


### PR DESCRIPTION
I notice that on iOS, plugin reads light from camera, but always read from back camera (I test on iPhone 15). I added an optional parameter to force read data from front camera. 

- The new parameter was called `frontCamera`, by default it's false.
 