### PR TITLE
remove: web plugin from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  web: ^1.1.0
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:


### PR DESCRIPTION
@ali-you 
Hello. Thanks for creating a great package.

### Purpose
I want to remove web plugin from pubspec.yaml.

### Issue
Version resolution with other packages is failing due to unused web plug-ins in this package.
The problem is that the following output is occurring.
```
[loovic_app] flutter pub get --no-example
Resolving dependencies...
Because firebase_messaging_web >=3.7.0 <3.9.0 depends on web ^0.5.1 and firebase_messaging_web >=3.10.5 depends on firebase_core ^3.13.0, firebase_messaging_web >=3.7.0 <3.9.0-∞ or >=3.10.5 requires web ^0.5.1 or firebase_core ^3.13.0.
And because firebase_messaging_web >=3.10.4 <3.10.5 depends on firebase_core ^3.12.1, firebase_messaging_web >=3.7.0 <3.9.0-∞ or >=3.10.4 requires web ^0.5.1 or firebase_core ^3.12.1.
And because firebase_messaging_web >=3.10.3 <3.10.4 depends on firebase_core ^3.12.0 and firebase_messaging_web >=3.10.2 <3.10.3 depends on firebase_core ^3.11.0, firebase_messaging_web >=3.7.0 <3.9.0-∞ or >=3.10.2 requires web ^0.5.1 or firebase_core ^3.11.0.
And because firebase_messaging_web >=3.10.1 <3.10.2 depends on firebase_core ^3.10.1 and firebase_messaging_web >=3.10.0 <3.10.1 depends on firebase_core ^3.10.0, firebase_messaging_web >=3.7.0 <3.9.0-∞ or >=3.10.0 requires web ^0.5.1 or firebase_core ^3.10.0.
And because firebase_messaging_web >=3.9.5 <3.10.0 depends on firebase_core ^3.8.1 and firebase_messaging_web >=3.9.4 <3.9.5 depends on firebase_core ^3.8.0, firebase_messaging_web >=3.7.0 <3.9.0-∞ or >=3.9.4 requires web ^0.5.1 or firebase_core ^3.8.0.
And because firebase_messaging_web >=3.9.3 <3.9.4 depends on firebase_core ^3.7.0 and firebase_messaging_web >=3.9.2 <3.9.3 depends on firebase_core ^3.6.0, firebase_messaging_web >=3.7.0 <3.9.0-∞ or >=3.9.2 requires web ^0.5.1 or firebase_core ^3.6.0.
And because firebase_messaging_web >=3.9.1 <3.9.2 depends on firebase_core ^3.5.0 and firebase_messaging_web >=3.9.0 <3.9.1 depends on firebase_core ^3.4.1, firebase_messaging_web >=3.7.0 requires firebase_core ^3.4.1 or web ^0.5.1.
Because no versions of firebase_messaging match >14.9.4 <15.0.0 and firebase_messaging 14.9.4 depends on firebase_messaging_web ^3.8.7, firebase_messaging ^14.9.4 requires firebase_messaging_web ^3.8.7.
Thus, firebase_messaging ^14.9.4 requires firebase_core ^3.4.1 or web ^0.5.1.
And because ambient_light >=0.0.5 depends on web ^1.1.0 and loovic depends on firebase_core ^2.32.0, firebase_messaging ^14.9.4 is incompatible with ambient_light >=0.0.5.
So, because loovic depends on both firebase_messaging ^14.9.4 and ambient_light ^0.1.1, version solving failed.
```

Thanks for reading this far.
Sorry for my poor English, but I hope this pull request will be adopted.